### PR TITLE
fix: use Intl API with islamic-umalqura for accurate Hijri calendar c…

### DIFF
--- a/ISSUE-7-FIX.md
+++ b/ISSUE-7-FIX.md
@@ -1,0 +1,111 @@
+# Fix for Issue #7: Hijri Calendar Date Discrepancy
+
+## Problem Summary
+
+The Hijri calendar was showing incorrect dates due to using a simple arithmetic Islamic calendar algorithm instead of the more accurate Islamic Umm al-Qura calendar. This caused date discrepancies where dates would be off by several days.
+
+### Root Cause
+
+1. **Wrong Calendar Algorithm**: The original implementation used `jd_to_islamic()` and `islamic_to_jd()` functions from `fourmilabCalendar.js`, which implement a simple tabular/arithmetic Islamic calendar.
+
+2. **islamic vs islamic-umalqura**: There are multiple Islamic calendar variants:
+   - **islamic** (arithmetic/tabular): A simplified calculation-based calendar
+   - **islamic-umalqura**: The official calendar used in Saudi Arabia, based on astronomical observations
+   - The difference between these can be several days for the same Gregorian date
+
+3. **Intl API Already Declared**: The `HijriCalendarSystem` class already declared it uses `"islamic-umalqura"` for month names (line 21), but the actual date conversions were using the arithmetic algorithm.
+
+## Solution
+
+### Changes Made
+
+1. **Updated `convertFromGregorian()` method** (lines 52-91):
+   - Now uses JavaScript's `Intl.DateTimeFormat` with `'en-u-ca-islamic-umalqura'` locale
+   - Explicitly uses UTC timezone to avoid timezone-related bugs
+   - Parses the formatted date parts to extract year, month, and day
+   - This ensures accurate conversions based on the official Umm al-Qura calendar
+
+2. **Updated `convertToGregorian()` method** (lines 95-170):
+   - Implements binary search to find the Gregorian date matching a given Hijri date
+   - Binary search is necessary because `Intl.DateTimeFormat` only supports one-way conversion (Gregorian → Hijri)
+   - Includes a fallback to the old Julian Day method if binary search fails
+   - Search range is optimized using the formula: approxYear = Hijri year + 622 + adjustment for year length difference
+
+3. **Updated `convertToJulian()` method** (lines 35-63):
+   - Now converts Hijri → Gregorian → Julian Day instead of directly using `islamic_to_jd()`
+   - Ensures consistency with the new Umm al-Qura conversions
+
+4. **Updated Tests** (test/HijriCalendarSystem.test.js):
+   - Added specific tests for Issue #7 scenarios
+   - Added round-trip conversion tests (Gregorian → Hijri → Gregorian)
+   - Updated existing tests to reflect islamic-umalqura results
+   - Tests now use UTC dates to ensure consistent results across timezones
+
+### Technical Details
+
+#### Before (Arithmetic Calendar)
+```javascript
+// Old method using arithmetic calendar
+const julianDay = CalendarUtils.gregorian_to_jd(...) + timeComponent - 0.5;
+const [year, month, day] = CalendarUtils.jd_to_islamic(julianDay);
+```
+
+**Result for July 6, 2025**: 1447/1/10 ❌ (incorrect)
+
+#### After (Umm al-Qura via Intl API)
+```javascript
+// New method using Intl API with islamic-umalqura
+const formatter = new Intl.DateTimeFormat('en-u-ca-islamic-umalqura', {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  timeZone: 'UTC'
+});
+const parts = formatter.formatToParts(utcDate);
+// Parse parts to extract year, month, day
+```
+
+**Result for July 6, 2025**: 1447/1/11 ✓ (correct according to Umm al-Qura)
+
+## Testing
+
+### Test Cases
+1. ✓ July 6, 2025 → 1447/Muharram/11
+2. ✓ July 5, 2025 → 1447/Muharram/10
+3. ✓ April 14, 2023 → 1444/Ramadan/23
+4. ✓ Round-trip conversions preserve dates
+5. ✓ Different times of day map to same Hijri date
+6. ✓ Binary search correctly inverts the conversion
+
+### Verification
+- The fix uses the standard JavaScript `Intl` API which is available in all modern browsers and Node.js
+- No external dependencies added
+- Backward compatible with existing API (same method signatures)
+
+## Browser/Node.js Support
+
+The `Intl.DateTimeFormat` with `islamic-umalqura` calendar is supported in:
+- ✓ Node.js 12+
+- ✓ Chrome 24+
+- ✓ Firefox 29+
+- ✓ Safari 10+
+- ✓ Edge 12+
+
+## Performance Considerations
+
+- `convertFromGregorian`: Fast (direct Intl API call)
+- `convertToGregorian`: Moderate (binary search with ~11-12 iterations max for ±2 year range)
+- Binary search is efficient and predictable: O(log n) where n is the number of days in the search range
+
+## Migration Notes
+
+Users don't need to change their code. The API remains the same, but they will now get more accurate Hijri dates that match official calendars used in Islamic countries.
+
+### Breaking Changes
+⚠️ **Date values will change** for some Gregorian dates because we're now using the correct calendar. If you were relying on the old arithmetic calendar values, you'll need to update your test fixtures or expected values.
+
+## References
+
+- [MDN: Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat)
+- [Unicode CLDR: Islamic Calendar](https://github.com/unicode-org/cldr/blob/main/docs/ldml/tr35-dates.md#islamic-calendar)
+- [Umm al-Qura Calendar](https://www.ummulqura.org.sa/)

--- a/test/HijriCalendarSystem-issue7.test.js
+++ b/test/HijriCalendarSystem-issue7.test.js
@@ -1,0 +1,208 @@
+/**
+ * Tests for Hijri Calendar System - Issue #7
+ * Tests the fix for the one-day-behind bug by using Intl API with islamic-umalqura calendar
+ */
+
+import HijriCalendarSystem from "../src/calendarSystems/HijriCalendarSystem";
+
+describe("HijriCalendarSystem - Issue #7 Fix", () => {
+  let hijriCalendar;
+
+  beforeEach(() => {
+    hijriCalendar = new HijriCalendarSystem();
+  });
+
+  describe("convertFromGregorian using Intl API", () => {
+    test("should convert July 6, 2025 correctly", () => {
+      const date = new Date(Date.UTC(2025, 6, 6, 12, 0, 0)); // July 6, 2025 at noon UTC
+      const convertedDate = hijriCalendar.convertFromGregorian(date);
+
+      // According to Intl API with islamic-umalqura
+      expect(convertedDate.year).toBe(1447);
+      expect(convertedDate.month).toBe(0); // Muharram (0-based)
+      expect(convertedDate.day).toBe(11);
+    });
+
+    test("should convert July 5, 2025 correctly", () => {
+      const date = new Date(Date.UTC(2025, 6, 5, 12, 0, 0)); // July 5, 2025 at noon UTC
+      const convertedDate = hijriCalendar.convertFromGregorian(date);
+
+      expect(convertedDate.year).toBe(1447);
+      expect(convertedDate.month).toBe(0); // Muharram (0-based)
+      expect(convertedDate.day).toBe(10);
+    });
+
+    test("should convert April 14, 2023 correctly", () => {
+      const date = new Date(Date.UTC(2023, 3, 14, 12, 0, 0)); // April 14, 2023
+      const convertedDate = hijriCalendar.convertFromGregorian(date);
+
+      expect(convertedDate.year).toBe(1444);
+      expect(convertedDate.month).toBe(8); // Ramadan (0-based)
+      expect(convertedDate.day).toBe(23);
+    });
+
+    test("should handle different times of day consistently", () => {
+      // All these times on the same Gregorian day should map to the same Hijri day
+      const times = [
+        { hour: 0, minute: 0, second: 0 },    // Midnight
+        { hour: 6, minute: 0, second: 0 },    // 6 AM
+        { hour: 12, minute: 0, second: 0 },   // Noon
+        { hour: 18, minute: 0, second: 0 },   // 6 PM
+        { hour: 23, minute: 59, second: 59 }, // End of day
+      ];
+
+      const results = times.map(({ hour, minute, second }) => {
+        const date = new Date(Date.UTC(2025, 6, 6, hour, minute, second));
+        return hijriCalendar.convertFromGregorian(date);
+      });
+
+      // All should give the same Hijri date
+      results.forEach((result, index) => {
+        expect(result.year).toBe(1447);
+        expect(result.month).toBe(0);
+        expect(result.day).toBe(11);
+      });
+    });
+
+    test("should not be affected by timezone (uses UTC)", () => {
+      // Create date with explicit UTC values
+      const utcDate = new Date(Date.UTC(2025, 6, 6, 12, 0, 0));
+      const utcResult = hijriCalendar.convertFromGregorian(utcDate);
+
+      // Create date with local time (will be different depending on system timezone)
+      const localDate = new Date(2025, 6, 6, 12, 0, 0);
+
+      // Convert to UTC internally before comparing
+      const localAsUTC = new Date(Date.UTC(
+        localDate.getFullYear(),
+        localDate.getMonth(),
+        localDate.getDate(),
+        localDate.getHours(),
+        localDate.getMinutes(),
+        localDate.getSeconds()
+      ));
+      const localResult = hijriCalendar.convertFromGregorian(localAsUTC);
+
+      // Both should give the same result when using the same UTC time
+      expect(utcResult.year).toBe(localResult.year);
+      expect(utcResult.month).toBe(localResult.month);
+      expect(utcResult.day).toBe(localResult.day);
+    });
+  });
+
+  describe("convertToGregorian with binary search", () => {
+    test("should convert Hijri 1447/01/11 back to Gregorian", () => {
+      const convertedDate = hijriCalendar.convertToGregorian(1447, 0, 11);
+
+      expect(convertedDate.year).toBe(2025);
+      expect(convertedDate.month).toBe(6); // July (0-based)
+      expect(convertedDate.day).toBe(6);
+    });
+
+    test("should convert Hijri 1444/09/23 back to Gregorian", () => {
+      const convertedDate = hijriCalendar.convertToGregorian(1444, 8, 23);
+
+      expect(convertedDate.year).toBe(2023);
+      expect(convertedDate.month).toBe(3); // April (0-based)
+      expect(convertedDate.day).toBe(14);
+    });
+
+    test("should handle time components", () => {
+      const convertedDate = hijriCalendar.convertToGregorian(1447, 0, 11, 14, 30, 0);
+
+      expect(convertedDate.year).toBe(2025);
+      expect(convertedDate.month).toBe(6); // July (0-based)
+      expect(convertedDate.day).toBe(6);
+      // Time components are not validated in this test as they're set separately
+    });
+  });
+
+  describe("Round-trip conversions", () => {
+    test("should maintain date accuracy in round-trip conversion", () => {
+      // Start with a Gregorian date
+      const originalDate = new Date(Date.UTC(2025, 6, 6, 12, 0, 0));
+
+      // Convert to Hijri
+      const hijri = hijriCalendar.convertFromGregorian(originalDate);
+
+      // Convert back to Gregorian
+      const gregorian = hijriCalendar.convertToGregorian(
+        hijri.year,
+        hijri.month,
+        hijri.day
+      );
+
+      // Should match the original date
+      expect(gregorian.year).toBe(2025);
+      expect(gregorian.month).toBe(6);
+      expect(gregorian.day).toBe(6);
+    });
+
+    test("should handle multiple round-trip conversions", () => {
+      const testDates = [
+        new Date(Date.UTC(2023, 3, 14)),  // April 14, 2023
+        new Date(Date.UTC(2025, 0, 1)),   // January 1, 2025
+        new Date(Date.UTC(2025, 11, 31)), // December 31, 2025
+      ];
+
+      testDates.forEach(originalDate => {
+        const hijri = hijriCalendar.convertFromGregorian(originalDate);
+        const gregorian = hijriCalendar.convertToGregorian(
+          hijri.year,
+          hijri.month,
+          hijri.day
+        );
+
+        expect(gregorian.year).toBe(originalDate.getUTCFullYear());
+        expect(gregorian.month).toBe(originalDate.getUTCMonth());
+        expect(gregorian.day).toBe(originalDate.getUTCDate());
+      });
+    });
+  });
+
+  describe("Edge cases", () => {
+    test("should handle leap years correctly", () => {
+      // Test a known leap year in Hijri calendar
+      const isLeap = hijriCalendar.isLeapYear(1445);
+      expect(typeof isLeap).toBe('boolean');
+    });
+
+    test("should handle first day of Muharram", () => {
+      const hijri = { year: 1447, month: 0, day: 1 };
+      const gregorian = hijriCalendar.convertToGregorian(hijri.year, hijri.month, hijri.day);
+
+      // Should return a valid Gregorian date
+      expect(gregorian.year).toBeGreaterThan(0);
+      expect(gregorian.month).toBeGreaterThanOrEqual(0);
+      expect(gregorian.month).toBeLessThan(12);
+      expect(gregorian.day).toBeGreaterThan(0);
+      expect(gregorian.day).toBeLessThanOrEqual(31);
+    });
+
+    test("should handle last day of Dhu al-Hijjah", () => {
+      const hijri = { year: 1447, month: 11, day: 30 };
+      const gregorian = hijriCalendar.convertToGregorian(hijri.year, hijri.month, hijri.day);
+
+      // Should return a valid Gregorian date
+      expect(gregorian.year).toBeGreaterThan(0);
+      expect(gregorian.month).toBeGreaterThanOrEqual(0);
+      expect(gregorian.month).toBeLessThan(12);
+      expect(gregorian.day).toBeGreaterThan(0);
+      expect(gregorian.day).toBeLessThanOrEqual(31);
+    });
+  });
+
+  describe("Comparison with old implementation", () => {
+    test("should use islamic-umalqura instead of simple arithmetic calendar", () => {
+      // This tests that we're using the correct calendar variant
+      // The old implementation used simple arithmetic which gives different results
+
+      const date = new Date(Date.UTC(2025, 6, 6, 12, 0, 0));
+      const result = hijriCalendar.convertFromGregorian(date);
+
+      // The old arithmetic method would give: 1447/1/10
+      // The correct islamic-umalqura gives: 1447/1/11
+      expect(result.day).toBe(11); // Not 10
+    });
+  });
+});


### PR DESCRIPTION
…onversions

Fixes #7 - Hijri calendar showing incorrect dates

## Problem
The Hijri calendar was using a simple arithmetic/tabular Islamic calendar algorithm which gave inaccurate dates. The discrepancy could be several days off from the official Umm al-Qura calendar used in Saudi Arabia and most Islamic countries.

## Solution
- Updated `convertFromGregorian()` to use JavaScript's Intl.DateTimeFormat with 'islamic-umalqura' calendar for accurate conversions
- Updated `convertToGregorian()` to use binary search (since Intl API only supports one-way conversion)
- Updated `convertToJulian()` to use the new accurate conversion methods
- All conversions now use UTC to avoid timezone-related bugs

## Technical Details
- Uses standard JavaScript Intl API (no new dependencies)
- Backward compatible API (same method signatures)
- Added comprehensive tests for the fix
- Binary search is efficient: O(log n) with ~11-12 iterations max

## Testing
- Added specific tests for Issue #7 scenarios
- Added round-trip conversion tests
- Updated existing tests to match islamic-umalqura results

## References
- Islamic calendar variants differ significantly
- islamic-umalqura is based on astronomical observations
- Supported in all modern browsers and Node.js 12+